### PR TITLE
Make moment random a (non dev) dependency

### DIFF
--- a/packages/base-dao/package.json
+++ b/packages/base-dao/package.json
@@ -35,6 +35,7 @@
     "async": "^3.1.0",
     "dataloader": "^1.4.0",
     "lodash": "^4.17.15",
+    "moment-random": "^1.0.5",
     "pluralize": "^8.0.0",
     "sequelize": "venn-city/sequelize#v5"
   },
@@ -54,7 +55,6 @@
     "jest": "^24.9.0",
     "jest-junit": "^9.0.0",
     "lint-staged": "^9.4.2",
-    "moment-random": "^1.0.5",
     "prettier": "^1.18.2",
     "sinon": "^7.5.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7223,7 +7223,7 @@ modify-values@^1.0.0:
 
 moment-random@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/moment-random/-/moment-random-1.0.5.tgz#d885382cf715cc18018a403e3aefda7177cdc3d6"
+  resolved "https://registry.npmjs.org/moment-random/-/moment-random-1.0.5.tgz#d885382cf715cc18018a403e3aefda7177cdc3d6"
   integrity sha512-zToKMGkYQyjTaDSKOUvnOTgSEr7f9wEDe1EuJ6Q3bxu09FSWninC0Ba9HLyWa3kzi/wVcWc0tMrI+gioXkw1ag==
 
 moment-timezone@^0.5.21:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7223,7 +7223,7 @@ modify-values@^1.0.0:
 
 moment-random@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.npmjs.org/moment-random/-/moment-random-1.0.5.tgz#d885382cf715cc18018a403e3aefda7177cdc3d6"
+  resolved "https://registry.yarnpkg.com/moment-random/-/moment-random-1.0.5.tgz#d885382cf715cc18018a403e3aefda7177cdc3d6"
   integrity sha512-zToKMGkYQyjTaDSKOUvnOTgSEr7f9wEDe1EuJ6Q3bxu09FSWninC0Ba9HLyWa3kzi/wVcWc0tMrI+gioXkw1ag==
 
 moment-timezone@^0.5.21:


### PR DESCRIPTION
This is needed because other packages that use the baseTestForDAO file
that requires this dependency currently need to install this dependency
themselves.