### PR TITLE
feat: throw a clear error if open crud introspection fails

### DIFF
--- a/packages/opencrud-schema-provider/src/openCRUDSchemaProvider/openCRUDSchemaProvider.js
+++ b/packages/opencrud-schema-provider/src/openCRUDSchemaProvider/openCRUDSchemaProvider.js
@@ -26,8 +26,13 @@ const openCrudSchema = makeExecutableSchema({
 });
 
 function getOpenCrudIntrospection() {
+  const openCrudIntrospection = graphqlSync(openCrudSchema, introspectionQuery);
+  if (openCrudIntrospection.errors) {
+    console.error('Failed getting open crud introspection. Errors: ', openCrudIntrospection.errors);
+    throw new Error(`Failed getting open crud introspection. Errors: ${JSON.stringify(openCrudIntrospection.errors)}`);
+  }
   // eslint-disable-next-line no-underscore-dangle
-  return graphqlSync(openCrudSchema, introspectionQuery).data.__schema;
+  return openCrudIntrospection.data.__schema;
 }
 
 module.exports = {


### PR DESCRIPTION
Before this fix the real errors are swallowed.

Writing tests for this is hard because it all is initialised immediately when the module is required