### PR TITLE
feat(graphql-transformers): dedup nXm pagination results

### DIFF
--- a/packages/graphql-transformers/src/openCrudWhereTransform/openCRUDtoSequelizeWhereTransformer.js
+++ b/packages/graphql-transformers/src/openCrudWhereTransform/openCRUDtoSequelizeWhereTransformer.js
@@ -19,13 +19,7 @@ const NOT = 'NOT';
 
 function openCrudToSequelize({ where, first, skip, orderBy = 'id_ASC' }, entityName, pathWithinSchema = [entityName], useColumnNames = false) {
   try {
-    if (!sq[entityName]) {
-      throw new Error(`No sequelize model defined for entity ${entityName}. Potential causes:
-        * Sequelize was not initialized (sq.init was not called)
-        * The sequelize model for ${entityName} was not defined correctly
-        * There is a package version clash and there are two versions of the @venncity/sequelize-model package
-      `);
-    }
+    validateSqInit(entityName);
     const sqWhereElements = [];
     const sqIncludeElements = [];
     let whereResult;
@@ -53,7 +47,8 @@ function openCrudToSequelize({ where, first, skip, orderBy = 'id_ASC' }, entityN
       include: sqIncludeElements,
       limit: first,
       offset: skip,
-      order: orderBy && [orderBy.split('_')]
+      order: orderBy && [orderBy.split('_')],
+      includeIgnoreAttributes: false
     };
     addSelectAttributes(sqFilter, entityName);
 
@@ -317,6 +312,16 @@ function pushNotEmpty(array, other) {
     } else {
       array.push(other);
     }
+  }
+}
+
+function validateSqInit(entityName) {
+  if (!sq[entityName]) {
+    throw new Error(`No sequelize model defined for entity ${entityName}. Potential causes:
+      * Sequelize was not initialized (sq.init was not called)
+      * The sequelize model for ${entityName} was not defined correctly
+      * There is a package version clash and there are two versions of the @venncity/sequelize-model package
+    `);
   }
 }
 

--- a/packages/sequelize-data-provider/src/sequelizeDataProviderPaging-test.js
+++ b/packages/sequelize-data-provider/src/sequelizeDataProviderPaging-test.js
@@ -261,4 +261,40 @@ describe('sequelizeDataProvider paging tests', () => {
     });
     expect(fetchedMinistries).toHaveLength(10);
   });
+
+  test('getAllEntities with nested _some filter for nxm relation, with limit', async () => {
+    async function createVotesForMinister(ministerId) {
+      for (let i = 0; i < 5; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await sequelizeDataProvider.createEntity('Vote', {
+          name: `${voteName1}${i}`,
+          ballot: voteBallot1,
+          minister: {
+            connect: {
+              id: ministerId
+            }
+          }
+        });
+      }
+    }
+
+    await createVotesForMinister(minister1.id);
+    await createVotesForMinister(minister2.id);
+
+    const fetchedMinisters = await sequelizeDataProvider.getAllEntities('Minister', {
+      where: {
+        AND: [
+          {
+            votes_some: { ballot: voteBallot1 }
+          },
+          {
+            name_in: [ministerName1, ministerName2]
+          }
+        ]
+      },
+      first: 2,
+      orderBy: 'createdAt_ASC'
+    });
+    expect(fetchedMinisters).toHaveLength(2);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,12 +3965,7 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-cuid@^2.1.6:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
-  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
-
-cuid@^2.1.8:
+cuid@^2.1.6, cuid@^2.1.8:
   version "2.1.8"
   resolved "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
   integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==


### PR DESCRIPTION
includeIgnoreAttributes: false does the trick by omitting any selected attributes on the join table,
so that only main table attributes are selected and there are no join-induced duplication in selected rows, which allows db-based pagination to work as expected.