### PR TITLE
Make the codegen naming convetion in generateDao consistent with the way it is in the services

### DIFF
--- a/packages/base-dao/CHANGELOG.md
+++ b/packages/base-dao/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.10.0-alpha.0](https://github.com/venn-city/graphql-clou/compare/@venncity/base-dao@1.9.13...@venncity/base-dao@1.10.0-alpha.0) (2020-07-17)
+
+**Note:** Version bump only for package @venncity/base-dao
+
+
+
+
+
 ## [1.9.13](https://github.com/venn-city/graphql-clou/compare/@venncity/base-dao@1.9.12...@venncity/base-dao@1.9.13) (2020-07-16)
 
 **Note:** Version bump only for package @venncity/base-dao

--- a/packages/base-dao/package.json
+++ b/packages/base-dao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venncity/base-dao",
-  "version": "1.9.13",
+  "version": "1.10.0-alpha.0",
   "author": "Venn Engineering",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/base-dao/package.json
+++ b/packages/base-dao/package.json
@@ -53,7 +53,6 @@
     "lodash": "^4.17.15",
     "moment-random": "^1.0.5",
     "pluralize": "^8.0.0",
-    "prisma-generate-schema": "^1.34.10",
     "yargs": "^15.0.2"
   },
   "devDependencies": {

--- a/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
+++ b/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
@@ -284,6 +284,13 @@ type Survey {
   deleted: Int!
 }
 
+enum SURVEY_RESPONSES {
+  VERY_HAPPY
+  HAPPY
+  SAD
+  VERY_SAD
+}
+
 type SurveyConnection {
   pageInfo: PageInfo!
   edges: [SurveyEdge]!
@@ -456,7 +463,7 @@ type SurveyQuestionPreviousValues {
 
 type SurveyQuestionResponse {
   id: ID!
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   question: SurveyQuestion!
   responderId: String
@@ -473,7 +480,7 @@ type SurveyQuestionResponseConnection {
 }
 
 input SurveyQuestionResponseCreateInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   question: SurveyQuestionCreateOneWithoutResponsesInput!
   responderId: String
@@ -487,7 +494,7 @@ input SurveyQuestionResponseCreateManyWithoutQuestionInput {
 }
 
 input SurveyQuestionResponseCreateWithoutQuestionInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   responderId: String
   deletedAt: DateTime
@@ -520,7 +527,7 @@ enum SurveyQuestionResponseOrderByInput {
 
 type SurveyQuestionResponsePreviousValues {
   id: ID!
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   responderId: String
   createdAt: DateTime!
@@ -544,20 +551,10 @@ input SurveyQuestionResponseScalarWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
-  value: String
-  value_not: String
-  value_in: [String!]
-  value_not_in: [String!]
-  value_lt: String
-  value_lte: String
-  value_gt: String
-  value_gte: String
-  value_contains: String
-  value_not_contains: String
-  value_starts_with: String
-  value_not_starts_with: String
-  value_ends_with: String
-  value_not_ends_with: String
+  value: SURVEY_RESPONSES
+  value_not: SURVEY_RESPONSES
+  value_in: [SURVEY_RESPONSES!]
+  value_not_in: [SURVEY_RESPONSES!]
   comment: String
   comment_not: String
   comment_in: [String!]
@@ -642,7 +639,7 @@ input SurveyQuestionResponseSubscriptionWhereInput {
 }
 
 input SurveyQuestionResponseUpdateInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   question: SurveyQuestionUpdateOneRequiredWithoutResponsesInput
   responderId: String
@@ -651,7 +648,7 @@ input SurveyQuestionResponseUpdateInput {
 }
 
 input SurveyQuestionResponseUpdateManyDataInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   responderId: String
   deletedAt: DateTime
@@ -659,7 +656,7 @@ input SurveyQuestionResponseUpdateManyDataInput {
 }
 
 input SurveyQuestionResponseUpdateManyMutationInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   responderId: String
   deletedAt: DateTime
@@ -684,7 +681,7 @@ input SurveyQuestionResponseUpdateManyWithWhereNestedInput {
 }
 
 input SurveyQuestionResponseUpdateWithoutQuestionDataInput {
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   responderId: String
   deletedAt: DateTime
@@ -717,20 +714,10 @@ input SurveyQuestionResponseWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
-  value: String
-  value_not: String
-  value_in: [String!]
-  value_not_in: [String!]
-  value_lt: String
-  value_lte: String
-  value_gt: String
-  value_gte: String
-  value_contains: String
-  value_not_contains: String
-  value_starts_with: String
-  value_not_starts_with: String
-  value_ends_with: String
-  value_not_ends_with: String
+  value: SURVEY_RESPONSES
+  value_not: SURVEY_RESPONSES
+  value_in: [SURVEY_RESPONSES!]
+  value_not_in: [SURVEY_RESPONSES!]
   comment: String
   comment_not: String
   comment_in: [String!]
@@ -1561,6 +1548,13 @@ export type SurveyQuestionsArgs = {
   last?: Maybe<Scalars['Int']>
 };
 
+export enum Survey_Responses {
+  VeryHappy = 'VERY_HAPPY',
+  Happy = 'HAPPY',
+  Sad = 'SAD',
+  VerySad = 'VERY_SAD'
+}
+
 export type SurveyConnection = {
    __typename?: 'SurveyConnection',
   pageInfo: PageInfo,
@@ -1753,7 +1747,7 @@ export type SurveyQuestionPreviousValues = {
 export type SurveyQuestionResponse = {
    __typename?: 'SurveyQuestionResponse',
   id: Scalars['ID'],
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   question: SurveyQuestion,
   responderId?: Maybe<Scalars['String']>,
@@ -1772,7 +1766,7 @@ export type SurveyQuestionResponseConnection = {
 };
 
 export type SurveyQuestionResponseCreateInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   question: SurveyQuestionCreateOneWithoutResponsesInput,
   responderId?: Maybe<Scalars['String']>,
@@ -1786,7 +1780,7 @@ export type SurveyQuestionResponseCreateManyWithoutQuestionInput = {
 };
 
 export type SurveyQuestionResponseCreateWithoutQuestionInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1821,7 +1815,7 @@ export enum SurveyQuestionResponseOrderByInput {
 export type SurveyQuestionResponsePreviousValues = {
    __typename?: 'SurveyQuestionResponsePreviousValues',
   id: Scalars['ID'],
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   createdAt: Scalars['DateTime'],
@@ -1845,20 +1839,10 @@ export type SurveyQuestionResponseScalarWhereInput = {
   id_not_starts_with?: Maybe<Scalars['ID']>,
   id_ends_with?: Maybe<Scalars['ID']>,
   id_not_ends_with?: Maybe<Scalars['ID']>,
-  value?: Maybe<Scalars['String']>,
-  value_not?: Maybe<Scalars['String']>,
-  value_in?: Maybe<Array<Scalars['String']>>,
-  value_not_in?: Maybe<Array<Scalars['String']>>,
-  value_lt?: Maybe<Scalars['String']>,
-  value_lte?: Maybe<Scalars['String']>,
-  value_gt?: Maybe<Scalars['String']>,
-  value_gte?: Maybe<Scalars['String']>,
-  value_contains?: Maybe<Scalars['String']>,
-  value_not_contains?: Maybe<Scalars['String']>,
-  value_starts_with?: Maybe<Scalars['String']>,
-  value_not_starts_with?: Maybe<Scalars['String']>,
-  value_ends_with?: Maybe<Scalars['String']>,
-  value_not_ends_with?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
+  value_not?: Maybe<Survey_Responses>,
+  value_in?: Maybe<Array<Survey_Responses>>,
+  value_not_in?: Maybe<Array<Survey_Responses>>,
   comment?: Maybe<Scalars['String']>,
   comment_not?: Maybe<Scalars['String']>,
   comment_in?: Maybe<Array<Scalars['String']>>,
@@ -1944,7 +1928,7 @@ export type SurveyQuestionResponseSubscriptionWhereInput = {
 };
 
 export type SurveyQuestionResponseUpdateInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   question?: Maybe<SurveyQuestionUpdateOneRequiredWithoutResponsesInput>,
   responderId?: Maybe<Scalars['String']>,
@@ -1953,7 +1937,7 @@ export type SurveyQuestionResponseUpdateInput = {
 };
 
 export type SurveyQuestionResponseUpdateManyDataInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1961,7 +1945,7 @@ export type SurveyQuestionResponseUpdateManyDataInput = {
 };
 
 export type SurveyQuestionResponseUpdateManyMutationInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1986,7 +1970,7 @@ export type SurveyQuestionResponseUpdateManyWithWhereNestedInput = {
 };
 
 export type SurveyQuestionResponseUpdateWithoutQuestionDataInput = {
-  value?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -2019,20 +2003,10 @@ export type SurveyQuestionResponseWhereInput = {
   id_not_starts_with?: Maybe<Scalars['ID']>,
   id_ends_with?: Maybe<Scalars['ID']>,
   id_not_ends_with?: Maybe<Scalars['ID']>,
-  value?: Maybe<Scalars['String']>,
-  value_not?: Maybe<Scalars['String']>,
-  value_in?: Maybe<Array<Scalars['String']>>,
-  value_not_in?: Maybe<Array<Scalars['String']>>,
-  value_lt?: Maybe<Scalars['String']>,
-  value_lte?: Maybe<Scalars['String']>,
-  value_gt?: Maybe<Scalars['String']>,
-  value_gte?: Maybe<Scalars['String']>,
-  value_contains?: Maybe<Scalars['String']>,
-  value_not_contains?: Maybe<Scalars['String']>,
-  value_starts_with?: Maybe<Scalars['String']>,
-  value_not_starts_with?: Maybe<Scalars['String']>,
-  value_ends_with?: Maybe<Scalars['String']>,
-  value_not_ends_with?: Maybe<Scalars['String']>,
+  value?: Maybe<Survey_Responses>,
+  value_not?: Maybe<Survey_Responses>,
+  value_in?: Maybe<Array<Survey_Responses>>,
+  value_not_in?: Maybe<Array<Survey_Responses>>,
   comment?: Maybe<Scalars['String']>,
   comment_not?: Maybe<Scalars['String']>,
   comment_in?: Maybe<Array<Scalars['String']>>,
@@ -2672,7 +2646,7 @@ scalar Json
 
 type SurveyQuestionResponse {
   id: ID!
-  value: String
+  value: SURVEY_RESPONSES
   comment: String
   question: SurveyQuestion!
   responderId: String
@@ -2697,20 +2671,10 @@ input SurveyQuestionResponseWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
-  value: String
-  value_not: String
-  value_in: [String!]
-  value_not_in: [String!]
-  value_lt: String
-  value_lte: String
-  value_gt: String
-  value_gte: String
-  value_contains: String
-  value_not_contains: String
-  value_starts_with: String
-  value_not_starts_with: String
-  value_ends_with: String
-  value_not_ends_with: String
+  value: SURVEY_RESPONSES
+  value_not: SURVEY_RESPONSES
+  value_in: [SURVEY_RESPONSES!]
+  value_not_in: [SURVEY_RESPONSES!]
   comment: String
   comment_not: String
   comment_in: [String!]
@@ -2909,6 +2873,13 @@ input SurveyWhereInput {
   AND: [SurveyWhereInput!]
   OR: [SurveyWhereInput!]
   NOT: [SurveyWhereInput!]
+}
+
+enum SURVEY_RESPONSES {
+  VERY_HAPPY
+  HAPPY
+  SAD
+  VERY_SAD
 }
 \`;
 "

--- a/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
+++ b/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
@@ -1382,9 +1382,9 @@ export type MutationDeleteManySurveyQuestionResponsesArgs = {
 };
 
 export enum MutationType {
-  Created = 'CREATED',
-  Updated = 'UPDATED',
-  Deleted = 'DELETED'
+  CREATED = 'CREATED',
+  UPDATED = 'UPDATED',
+  DELETED = 'DELETED'
 }
 
 export type Node = {
@@ -1548,11 +1548,11 @@ export type SurveyQuestionsArgs = {
   last?: Maybe<Scalars['Int']>
 };
 
-export enum Survey_Responses {
-  VeryHappy = 'VERY_HAPPY',
-  Happy = 'HAPPY',
-  Sad = 'SAD',
-  VerySad = 'VERY_SAD'
+export enum SurveyResponses {
+  VERY_HAPPY = 'VERY_HAPPY',
+  HAPPY = 'HAPPY',
+  SAD = 'SAD',
+  VERY_SAD = 'VERY_SAD'
 }
 
 export type SurveyConnection = {
@@ -1597,28 +1597,28 @@ export type SurveyEdge = {
 };
 
 export enum SurveyOrderByInput {
-  IdAsc = 'id_ASC',
-  IdDesc = 'id_DESC',
-  NameAsc = 'name_ASC',
-  NameDesc = 'name_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC',
-  DescriptionAsc = 'description_ASC',
-  DescriptionDesc = 'description_DESC',
-  EnabledAsc = 'enabled_ASC',
-  EnabledDesc = 'enabled_DESC',
-  IsAnonymousAsc = 'isAnonymous_ASC',
-  IsAnonymousDesc = 'isAnonymous_DESC',
-  HoodIdAsc = 'hoodId_ASC',
-  HoodIdDesc = 'hoodId_DESC',
-  CreatedAtAsc = 'createdAt_ASC',
-  CreatedAtDesc = 'createdAt_DESC',
-  UpdatedAtAsc = 'updatedAt_ASC',
-  UpdatedAtDesc = 'updatedAt_DESC',
-  DeletedAtAsc = 'deletedAt_ASC',
-  DeletedAtDesc = 'deletedAt_DESC',
-  DeletedAsc = 'deleted_ASC',
-  DeletedDesc = 'deleted_DESC'
+  ID_ASC = 'id_ASC',
+  ID_DESC = 'id_DESC',
+  NAME_ASC = 'name_ASC',
+  NAME_DESC = 'name_DESC',
+  TITLE_ASC = 'title_ASC',
+  TITLE_DESC = 'title_DESC',
+  DESCRIPTION_ASC = 'description_ASC',
+  DESCRIPTION_DESC = 'description_DESC',
+  ENABLED_ASC = 'enabled_ASC',
+  ENABLED_DESC = 'enabled_DESC',
+  ISANONYMOUS_ASC = 'isAnonymous_ASC',
+  ISANONYMOUS_DESC = 'isAnonymous_DESC',
+  HOODID_ASC = 'hoodId_ASC',
+  HOODID_DESC = 'hoodId_DESC',
+  CREATEDAT_ASC = 'createdAt_ASC',
+  CREATEDAT_DESC = 'createdAt_DESC',
+  UPDATEDAT_ASC = 'updatedAt_ASC',
+  UPDATEDAT_DESC = 'updatedAt_DESC',
+  DELETEDAT_ASC = 'deletedAt_ASC',
+  DELETEDAT_DESC = 'deletedAt_DESC',
+  DELETED_ASC = 'deleted_ASC',
+  DELETED_DESC = 'deleted_DESC'
 }
 
 export type SurveyPreviousValues = {
@@ -1714,22 +1714,22 @@ export type SurveyQuestionEdge = {
 };
 
 export enum SurveyQuestionOrderByInput {
-  IdAsc = 'id_ASC',
-  IdDesc = 'id_DESC',
-  TextAsc = 'text_ASC',
-  TextDesc = 'text_DESC',
-  OptionsAsc = 'options_ASC',
-  OptionsDesc = 'options_DESC',
-  AddCommentFieldAsc = 'addCommentField_ASC',
-  AddCommentFieldDesc = 'addCommentField_DESC',
-  CreatedAtAsc = 'createdAt_ASC',
-  CreatedAtDesc = 'createdAt_DESC',
-  UpdatedAtAsc = 'updatedAt_ASC',
-  UpdatedAtDesc = 'updatedAt_DESC',
-  DeletedAtAsc = 'deletedAt_ASC',
-  DeletedAtDesc = 'deletedAt_DESC',
-  DeletedAsc = 'deleted_ASC',
-  DeletedDesc = 'deleted_DESC'
+  ID_ASC = 'id_ASC',
+  ID_DESC = 'id_DESC',
+  TEXT_ASC = 'text_ASC',
+  TEXT_DESC = 'text_DESC',
+  OPTIONS_ASC = 'options_ASC',
+  OPTIONS_DESC = 'options_DESC',
+  ADDCOMMENTFIELD_ASC = 'addCommentField_ASC',
+  ADDCOMMENTFIELD_DESC = 'addCommentField_DESC',
+  CREATEDAT_ASC = 'createdAt_ASC',
+  CREATEDAT_DESC = 'createdAt_DESC',
+  UPDATEDAT_ASC = 'updatedAt_ASC',
+  UPDATEDAT_DESC = 'updatedAt_DESC',
+  DELETEDAT_ASC = 'deletedAt_ASC',
+  DELETEDAT_DESC = 'deletedAt_DESC',
+  DELETED_ASC = 'deleted_ASC',
+  DELETED_DESC = 'deleted_DESC'
 }
 
 export type SurveyQuestionPreviousValues = {
@@ -1747,7 +1747,7 @@ export type SurveyQuestionPreviousValues = {
 export type SurveyQuestionResponse = {
    __typename?: 'SurveyQuestionResponse',
   id: Scalars['ID'],
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   question: SurveyQuestion,
   responderId?: Maybe<Scalars['String']>,
@@ -1766,7 +1766,7 @@ export type SurveyQuestionResponseConnection = {
 };
 
 export type SurveyQuestionResponseCreateInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   question: SurveyQuestionCreateOneWithoutResponsesInput,
   responderId?: Maybe<Scalars['String']>,
@@ -1780,7 +1780,7 @@ export type SurveyQuestionResponseCreateManyWithoutQuestionInput = {
 };
 
 export type SurveyQuestionResponseCreateWithoutQuestionInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1794,28 +1794,28 @@ export type SurveyQuestionResponseEdge = {
 };
 
 export enum SurveyQuestionResponseOrderByInput {
-  IdAsc = 'id_ASC',
-  IdDesc = 'id_DESC',
-  ValueAsc = 'value_ASC',
-  ValueDesc = 'value_DESC',
-  CommentAsc = 'comment_ASC',
-  CommentDesc = 'comment_DESC',
-  ResponderIdAsc = 'responderId_ASC',
-  ResponderIdDesc = 'responderId_DESC',
-  CreatedAtAsc = 'createdAt_ASC',
-  CreatedAtDesc = 'createdAt_DESC',
-  UpdatedAtAsc = 'updatedAt_ASC',
-  UpdatedAtDesc = 'updatedAt_DESC',
-  DeletedAtAsc = 'deletedAt_ASC',
-  DeletedAtDesc = 'deletedAt_DESC',
-  DeletedAsc = 'deleted_ASC',
-  DeletedDesc = 'deleted_DESC'
+  ID_ASC = 'id_ASC',
+  ID_DESC = 'id_DESC',
+  VALUE_ASC = 'value_ASC',
+  VALUE_DESC = 'value_DESC',
+  COMMENT_ASC = 'comment_ASC',
+  COMMENT_DESC = 'comment_DESC',
+  RESPONDERID_ASC = 'responderId_ASC',
+  RESPONDERID_DESC = 'responderId_DESC',
+  CREATEDAT_ASC = 'createdAt_ASC',
+  CREATEDAT_DESC = 'createdAt_DESC',
+  UPDATEDAT_ASC = 'updatedAt_ASC',
+  UPDATEDAT_DESC = 'updatedAt_DESC',
+  DELETEDAT_ASC = 'deletedAt_ASC',
+  DELETEDAT_DESC = 'deletedAt_DESC',
+  DELETED_ASC = 'deleted_ASC',
+  DELETED_DESC = 'deleted_DESC'
 }
 
 export type SurveyQuestionResponsePreviousValues = {
    __typename?: 'SurveyQuestionResponsePreviousValues',
   id: Scalars['ID'],
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   createdAt: Scalars['DateTime'],
@@ -1839,10 +1839,10 @@ export type SurveyQuestionResponseScalarWhereInput = {
   id_not_starts_with?: Maybe<Scalars['ID']>,
   id_ends_with?: Maybe<Scalars['ID']>,
   id_not_ends_with?: Maybe<Scalars['ID']>,
-  value?: Maybe<Survey_Responses>,
-  value_not?: Maybe<Survey_Responses>,
-  value_in?: Maybe<Array<Survey_Responses>>,
-  value_not_in?: Maybe<Array<Survey_Responses>>,
+  value?: Maybe<SurveyResponses>,
+  value_not?: Maybe<SurveyResponses>,
+  value_in?: Maybe<Array<SurveyResponses>>,
+  value_not_in?: Maybe<Array<SurveyResponses>>,
   comment?: Maybe<Scalars['String']>,
   comment_not?: Maybe<Scalars['String']>,
   comment_in?: Maybe<Array<Scalars['String']>>,
@@ -1928,7 +1928,7 @@ export type SurveyQuestionResponseSubscriptionWhereInput = {
 };
 
 export type SurveyQuestionResponseUpdateInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   question?: Maybe<SurveyQuestionUpdateOneRequiredWithoutResponsesInput>,
   responderId?: Maybe<Scalars['String']>,
@@ -1937,7 +1937,7 @@ export type SurveyQuestionResponseUpdateInput = {
 };
 
 export type SurveyQuestionResponseUpdateManyDataInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1945,7 +1945,7 @@ export type SurveyQuestionResponseUpdateManyDataInput = {
 };
 
 export type SurveyQuestionResponseUpdateManyMutationInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -1970,7 +1970,7 @@ export type SurveyQuestionResponseUpdateManyWithWhereNestedInput = {
 };
 
 export type SurveyQuestionResponseUpdateWithoutQuestionDataInput = {
-  value?: Maybe<Survey_Responses>,
+  value?: Maybe<SurveyResponses>,
   comment?: Maybe<Scalars['String']>,
   responderId?: Maybe<Scalars['String']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -2003,10 +2003,10 @@ export type SurveyQuestionResponseWhereInput = {
   id_not_starts_with?: Maybe<Scalars['ID']>,
   id_ends_with?: Maybe<Scalars['ID']>,
   id_not_ends_with?: Maybe<Scalars['ID']>,
-  value?: Maybe<Survey_Responses>,
-  value_not?: Maybe<Survey_Responses>,
-  value_in?: Maybe<Array<Survey_Responses>>,
-  value_not_in?: Maybe<Array<Survey_Responses>>,
+  value?: Maybe<SurveyResponses>,
+  value_not?: Maybe<SurveyResponses>,
+  value_in?: Maybe<Array<SurveyResponses>>,
+  value_not_in?: Maybe<Array<SurveyResponses>>,
   comment?: Maybe<Scalars['String']>,
   comment_not?: Maybe<Scalars['String']>,
   comment_in?: Maybe<Array<Scalars['String']>>,

--- a/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
+++ b/packages/base-dao/tools/__snapshots__/generateDaoSchema-test.js.snap
@@ -1402,13 +1402,13 @@ export type PageInfo = {
 export type Query = {
    __typename?: 'Query',
   survey?: Maybe<Survey>,
-  surveys: Array<Maybe<Survey>>,
+  surveys: Array<Survey>,
   surveysConnection: SurveyConnection,
   surveyQuestion?: Maybe<SurveyQuestion>,
-  surveyQuestions: Array<Maybe<SurveyQuestion>>,
+  surveyQuestions: Array<SurveyQuestion>,
   surveyQuestionsConnection: SurveyQuestionConnection,
   surveyQuestionResponse?: Maybe<SurveyQuestionResponse>,
-  surveyQuestionResponses: Array<Maybe<SurveyQuestionResponse>>,
+  surveyQuestionResponses: Array<SurveyQuestionResponse>,
   surveyQuestionResponsesConnection: SurveyQuestionResponseConnection,
   node?: Maybe<Node>,
 };

--- a/packages/base-dao/tools/fixtures/datamodel.graphql
+++ b/packages/base-dao/tools/fixtures/datamodel.graphql
@@ -15,6 +15,13 @@ enum OPERATION {
   DISCONNECT_DELETE
 }
 
+enum SURVEY_RESPONSES {
+  VERY_HAPPY
+  HAPPY
+  SAD
+  VERY_SAD
+}
+
 type Survey @pgTable(name:"surveys") {
   id:                     ID!                     @unique
   name:                   String                  @pgColumn(name: "name") @unique
@@ -45,7 +52,7 @@ type SurveyQuestion @pgTable(name:"survey_questions") {
 
 type SurveyQuestionResponse @pgTable(name:"survey_question_responses") {
   id:                     ID!                     @unique
-  value:                  String                  @pgColumn(name: "value")
+  value:                  SURVEY_RESPONSES        @pgColumn(name: "value")
   comment:                String                  @pgColumn(name: "comment")
   question:               SurveyQuestion!         @pgRelation(column: "survey_question_id")
   responderId:            String                  @pgColumn(name: "responder_id")

--- a/packages/base-dao/tools/generateDaoClasses.js
+++ b/packages/base-dao/tools/generateDaoClasses.js
@@ -1,6 +1,6 @@
 const { lowerFirst, upperFirst } = require('lodash');
 const pluralize = require('pluralize');
-const { parseInternalTypes } = require('prisma-generate-schema');
+const { parseInternalTypes } = require('@venncity/prisma-generate-schema');
 const ejs = require('ejs');
 const path = require('path');
 

--- a/packages/base-dao/tools/generateOpenCrudSchemaTypes.js
+++ b/packages/base-dao/tools/generateOpenCrudSchemaTypes.js
@@ -1,4 +1,4 @@
-const { parseInternalTypes, generateCRUDSchemaFromInternalISDL } = require('prisma-generate-schema');
+const { parseInternalTypes, generateCRUDSchemaFromInternalISDL } = require('@venncity/prisma-generate-schema');
 const { plugin } = require('@graphql-codegen/typescript');
 const { codegen } = require('@graphql-codegen/core');
 const { printSchema, parse, GraphQLID, GraphQLNonNull } = require('graphql');

--- a/packages/base-dao/tools/generateOpenCrudSchemaTypes.js
+++ b/packages/base-dao/tools/generateOpenCrudSchemaTypes.js
@@ -8,6 +8,13 @@ function generateOpenCrudSchemaTypes(dataModel) {
 
   return codegen({
     schema,
+    config: {
+      namingConvention: {
+        typeNames: 'change-case#pascalCase',
+        enumValues: 'change-case#upperCase',
+        transformUnderscore: true
+      }
+    },
     plugins: [{ typescript: {} }],
     documents: [],
     pluginMap: {


### PR DESCRIPTION
To see the effect of this change look at the diff in the snapshot file in the second commit.