### PR TITLE
performance fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ a schematic and somehow simplistic illustration of a common flow between the pac
 ## Development guide:
 * circleci is used for ci, see `.circleci/config.yml` for details
 
+### Building
+```shell script
+$ yarn 
+$ yarn lerna run build
+```
+
 ### Running a local server:
 * To run a local apollo-server using the provided test entities, for a more interactive experience,
     you can run:

--- a/packages/base-dao/src/baseDAO.ts
+++ b/packages/base-dao/src/baseDAO.ts
@@ -88,7 +88,6 @@ export function createEntityDAO({ entityName, hooks, pluralizationFunction = plu
     }
 
     const resolvedEntities = await dataProvider.getAllEntities(entityName, args);
-    // update dataLoaderById, to avoid extra db calls later on
     resolvedEntities.forEach(entity => {
       dataLoaderById.prime(entity.id, entity);
     });


### PR DESCRIPTION
store fetch all entities into the dataloader to avoid extra selects
at get all entities function, change the loop caling getAuthDataFromDB to async library each which will call all of them in paralel - allowing the dataLoader to batch it if needed