### PR TITLE
fix: Performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "db:createSchema": "wait-on -d 10000 tcp:$npm_package_config_db_port && PGPASSWORD=postgres psql -d venn -U postgres -h localhost -p $npm_package_config_db_port -c \"CREATE SCHEMA IF NOT EXISTS venn;\"",
     "db:migrate": "wait-on tcp:$npm_package_config_db_port && NODE_ENV=test sequelize-cli db:migrate",
     "db:seed": "NODE_ENV=test sequelize-cli db:seed:all",
-    "db:start": "DB_PORT=$npm_package_config_db_port docker-compose up -d"
+    "db:start": "DB_PORT=$npm_package_config_db_port docker-compose up -d",
+    "db:stop": "DB_PORT=$npm_package_config_db_port docker-compose down "
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "db:migrate": "wait-on tcp:$npm_package_config_db_port && NODE_ENV=test sequelize-cli db:migrate",
     "db:seed": "NODE_ENV=test sequelize-cli db:seed:all",
     "db:start": "DB_PORT=$npm_package_config_db_port docker-compose up -d",
-    "db:stop": "DB_PORT=$npm_package_config_db_port docker-compose down "
+    "db:stop": "DB_PORT=$npm_package_config_db_port docker-compose down"
   },
   "husky": {
     "hooks": {

--- a/packages/base-dao/src/baseDAO.ts
+++ b/packages/base-dao/src/baseDAO.ts
@@ -183,11 +183,11 @@ export function createEntityDAO({ entityName, hooks, pluralizationFunction = plu
       const auth = await buildAuth(context, hooks);
       const entities = await dataLoaderById.loadMany(entityIds);
       const entitiesWithOnlyAuthorizedFields: any = [];
-      for (const entity of entities) {
+      await asyncEach(entities, async (entity: any) => {
         let entityWithOnlyAuthorizedFields = await verifyHasPermissionAndFilterUnauthorizedFields(context, auth, entity, hooks, authTypeName);
         entityWithOnlyAuthorizedFields = await hooks.postFetch(entityWithOnlyAuthorizedFields, context);
         entitiesWithOnlyAuthorizedFields.push(entityWithOnlyAuthorizedFields);
-      }
+      });
       return entitiesWithOnlyAuthorizedFields;
     },
     // e.g createUnit
@@ -427,11 +427,11 @@ export function createEntityDAO({ entityName, hooks, pluralizationFunction = plu
       const fetchedEntities = await fetchFunction();
       const iterableFetchedEntities = Array.isArray(fetchedEntities) ? fetchedEntities : [fetchedEntities];
       const entitiesWithOnlyAuthorizedFields: any = [];
-      for (const entity of iterableFetchedEntities) {
+      await asyncEach(iterableFetchedEntities, async (entity: any) => {
         let entityWithOnlyAuthorizedFields = await verifyHasPermissionAndFilterUnauthorizedFields(context, auth, entity, hooks, authTypeName);
         entityWithOnlyAuthorizedFields = await hooks.postFetch(entityWithOnlyAuthorizedFields, context);
         entitiesWithOnlyAuthorizedFields.push(entityWithOnlyAuthorizedFields);
-      }
+      });
       return entitiesWithOnlyAuthorizedFields;
     },
     getHooks: () => {

--- a/packages/sequelize-data-provider/src/batchDataProvider.ts
+++ b/packages/sequelize-data-provider/src/batchDataProvider.ts
@@ -18,9 +18,8 @@ export async function loadRelatedEntities(
   getRelatedEntities: (entityName: string, originalEntityId: string, relationFieldName: string, args?: any) => any
 ) {
   const [keysWithoutArgs, keysWithArgs] = partition(keys, key => {
-    const noArgs = isEmpty(key.args);
-    const objWithOnlySkipPagination = isEqual(key.args, { skipPagination: true }) || isEqual(key.args, { skipPagination: false });
-    return noArgs || objWithOnlySkipPagination;
+    const { skipPagination, ...newArg } = key?.args;
+    return isEmpty(newArg);
   });
 
   const originalEntitiesWithoutArgs = await fetchEntitiesWithRelations(keysWithoutArgs, entityName);

--- a/packages/sequelize-data-provider/src/batchDataProvider.ts
+++ b/packages/sequelize-data-provider/src/batchDataProvider.ts
@@ -17,10 +17,11 @@ export async function loadRelatedEntities(
   keys: readonly GetRelatedEntitiesArgs[],
   getRelatedEntities: (entityName: string, originalEntityId: string, relationFieldName: string, args?: any) => any
 ) {
-  const [keysWithoutArgs, keysWithArgs] = partition(
-    keys,
-    k => isEmpty(k.args) || isEqual(k.args, { skipPagination: true }) || isEqual(k.args, { skipPagination: false })
-  );
+  const [keysWithoutArgs, keysWithArgs] = partition(keys, key => {
+    const noArgs = isEmpty(key.args);
+    const objWithOnlySkipPagination = isEqual(key.args, { skipPagination: true }) || isEqual(key.args, { skipPagination: false });
+    return noArgs || objWithOnlySkipPagination;
+  });
 
   const originalEntitiesWithoutArgs = await fetchEntitiesWithRelations(keysWithoutArgs, entityName);
   const originalEntitiesWithArgs: { key: GetRelatedEntitiesArgs; relatedEntitiesWithArgs: any[] }[] = await async.map(

--- a/packages/sequelize-data-provider/src/batchDataProvider.ts
+++ b/packages/sequelize-data-provider/src/batchDataProvider.ts
@@ -1,4 +1,4 @@
-import { partition, uniq, upperFirst, isEmpty } from 'lodash';
+import { partition, uniq, upperFirst, isEmpty, isObject } from 'lodash';
 import async from 'async';
 import sequelizeModel from '@venncity/sequelize-model';
 import opencrudSchemaProvider from '@venncity/opencrud-schema-provider';
@@ -18,8 +18,13 @@ export async function loadRelatedEntities(
   getRelatedEntities: (entityName: string, originalEntityId: string, relationFieldName: string, args?: any) => any
 ) {
   const [keysWithoutArgs, keysWithArgs] = partition(keys, key => {
-    const { skipPagination, ...newArg } = key?.args;
-    return isEmpty(newArg);
+    const args = key.args;
+    if (isObject(args)) {
+      // @ts-ignore
+      const { skipPagination, ...newArg } = args;
+      return isEmpty(newArg);
+    }
+    return true;
   });
 
   const originalEntitiesWithoutArgs = await fetchEntitiesWithRelations(keysWithoutArgs, entityName);

--- a/packages/sequelize-data-provider/src/batchDataProvider.ts
+++ b/packages/sequelize-data-provider/src/batchDataProvider.ts
@@ -1,4 +1,4 @@
-import { partition, uniq, upperFirst, isEmpty } from 'lodash';
+import { partition, uniq, upperFirst, isEmpty, isEqual } from 'lodash';
 import async from 'async';
 import sequelizeModel from '@venncity/sequelize-model';
 import opencrudSchemaProvider from '@venncity/opencrud-schema-provider';
@@ -17,7 +17,10 @@ export async function loadRelatedEntities(
   keys: readonly GetRelatedEntitiesArgs[],
   getRelatedEntities: (entityName: string, originalEntityId: string, relationFieldName: string, args?: any) => any
 ) {
-  const [keysWithoutArgs, keysWithArgs] = partition(keys, k => isEmpty(k.args));
+  const [keysWithoutArgs, keysWithArgs] = partition(
+    keys,
+    k => isEmpty(k.args) || isEqual(k.args, { skipPagination: true }) || isEqual(k.args, { skipPagination: false })
+  );
 
   const originalEntitiesWithoutArgs = await fetchEntitiesWithRelations(keysWithoutArgs, entityName);
   const originalEntitiesWithArgs: { key: GetRelatedEntitiesArgs; relatedEntitiesWithArgs: any[] }[] = await async.map(

--- a/packages/sequelize-data-provider/src/batchDataProvider.ts
+++ b/packages/sequelize-data-provider/src/batchDataProvider.ts
@@ -1,4 +1,4 @@
-import { partition, uniq, upperFirst, isEmpty, isEqual } from 'lodash';
+import { partition, uniq, upperFirst, isEmpty } from 'lodash';
 import async from 'async';
 import sequelizeModel from '@venncity/sequelize-model';
 import opencrudSchemaProvider from '@venncity/opencrud-schema-provider';

--- a/packages/sequelize-data-provider/src/sequelizeDataProvider.test.ts
+++ b/packages/sequelize-data-provider/src/sequelizeDataProvider.test.ts
@@ -626,6 +626,36 @@ describe('sequelizeDataProvider', () => {
         expect(relatedMinistries2).toEqual([]);
       });
 
+      test('loadRelatedEntities multiple keys with arg skipPagination - work as planned', async () => {
+        const [relatedMinistries1, relatedLobbyists1, relatedMinistries2] = await loadRelatedEntities(
+          'Government',
+          [
+            { originalEntityId: government1.id, relationEntityName: 'ministries', args: { where: { name: ministry2.name }, skipPagination: true } },
+            { originalEntityId: government1.id, relationEntityName: 'lobbyists', args: { skipPagination: false } },
+            { originalEntityId: government2.id, relationEntityName: 'ministries' }
+          ],
+          sequelizeDataProvider.getRelatedEntities
+        );
+        expect(relatedMinistries1.map(g => g.id).sort()).toEqual([ministry2.id].sort());
+        expect(relatedLobbyists1).toEqual([]);
+        expect(relatedMinistries2).toEqual([]);
+      });
+      test('loadRelatedEntities multiple keys with arg skipPagination call getRelatedEntities once', async () => {
+        const mockCallback = jest.fn(x => 42 + x);
+        await loadRelatedEntities(
+          'Government',
+          [
+            { originalEntityId: government1.id, relationEntityName: 'ministries', args: { skipPagination: true } },
+            { originalEntityId: government1.id, relationEntityName: 'lobbyists', args: { skipPagination: false } },
+            { originalEntityId: government2.id, relationEntityName: 'ministries', args: { where: { name: ministry2.name } } }
+          ],
+          mockCallback
+        );
+
+        expect(mockCallback.mock.calls.length).toBe(1);
+        expect(mockCallback.mock.calls[0][1]).toBe(government2.id);
+      });
+
       test('loadRelatedEntities multiple keys with different args', async () => {
         const lobbyist1 = await sequelizeDataProvider.createEntity('Lobbyist', {
           name: `lobbyist1${randomNumber}`,

--- a/packages/sequelize-data-provider/src/sequelizeDataProvider.test.ts
+++ b/packages/sequelize-data-provider/src/sequelizeDataProvider.test.ts
@@ -653,6 +653,7 @@ describe('sequelizeDataProvider', () => {
         );
 
         expect(mockCallback.mock.calls.length).toBe(1);
+        // @ts-ignore
         expect(mockCallback.mock.calls[0][1]).toBe(government2.id);
       });
 


### PR DESCRIPTION
replace for loops with async each in baseDAo for performace.

disregard skipPagination when splitting the loading process in loadRelatedEntities - in order to to use the dataloader when possible,

missing db:stop in package.json